### PR TITLE
Sancus step spy module

### DIFF
--- a/include/sancus_support/sancus_step.h
+++ b/include/sancus_support/sancus_step.h
@@ -15,15 +15,15 @@
 
 #define INIT_LATENCY 1
 
-void print_latency(void);
-int get_latency(void);
+void sancus_step_print_latency(void);
+int sancus_step_get_latency(void);
 
-// new interface
+// sancus step interface
 void sancus_step_start(void);
 void sancus_step_init(void);
 void sancus_step_end(void);
-void sancus_step_isr_main(void);
 
+// sancus step configuration parameters
 int ss_dbg_entry_delay;
 int ss_dbg_measuring_reti_latency;
 int isr_reti_latency;
@@ -35,24 +35,69 @@ int SM_ENTRY(ssdbg) ss_dbg_get_info(void);
 
 volatile int      __ss_isr_tar_entry;
 
+/*
+    if (isr_interrupted_sm)
+    {
+        if (ss_dbg_measuring_reti_latency)
+        {
+            TACTL = TACTL_DISABLE;
+            TACTL = TACTL_CONTINUOUS;
+        }
+        else
+        {
+            print_latency();
+            timer_irq(isr_reti_latency);
+        }
+    }
+    else
+    {
+        timer_disable();
+    }
+*/
+
 #define SANCUS_STEP_ISR_ENTRY(fct)                                  \
 __attribute__((naked)) __attribute__((interrupt(TIMER_IRQ_VECTOR))) \
 void timerA_isr_entry(void)                                         \
 {                                                                   \
-    __asm__("mov &%0, &__ss_isr_tar_entry\n\t"                      \
+    __asm__("mov &%0, &%2; save tar\n\t"                            \
+            "mov #0x4, &%4; disable timer\n\t "                     \
+            "mov #0x0, &%1\n\t"                                     \
             "cmp #0x0, r1\n\t"                                      \
             "jne 1f\n\t"                                            \
             "; sm got interrupted\n\t"                              \
-            "mov #0x1, &isr_interrupted_sm\n\t"                     \
-            "jmp cont\n\t"                                          \
-            "1: mov #0x0, &isr_interrupted_sm\n\t"                  \
-            "cont:\n\t"                                             \
-            "mov &__isr_sp, r1\n\t"                                 \
+            "mov #0x1, &%1\n\t"                                     \
+            "mov &%3, r1\n\t"                                       \
             "push r15\n\t"                                          \
             "push #0x0\n\t"                                         \
+            "cmp #0x0, &%7\n\t"                                     \
+            "jz 2f\n\t"                                             \
+            "; measuring isr_reti_latency\n\t"                      \
+            "mov #0x220, &%4; set timer in continuous mode\n\t"     \
+            "jmp 3f\n\t"                                            \
+            "2: ; not measuring isr_reti_latency\n\t"               \
             "call #" #fct "\n\t"                                    \
-            "reti\n\t"                                              \
-            ::"m"(TAR):);                                           \
+            "push r15\n\t"                                          \
+            "mov &%6, r15\n\t"                                      \
+            "add #0x5, r15 ;\n\t"                                   \
+            "mov r15, &%5\n\t"                                      \
+            "pop r15\n\t"                                           \
+            "mov #0x212, &%4; set timer in interrupt mode (irq)\n\t"\
+            "jmp 3f\n\t"                                            \
+            "1: ; sm not interrupted\n\t"                           \
+            "call #timer_disable\n\t"                               \
+            "3: reti\n\t"                                           \
+            :                                                       \
+            :                                                       \
+            "m"(TAR),                                               \
+            "m"(isr_interrupted_sm),                                \
+            "m"(__ss_isr_tar_entry),                                \
+            "m"(__isr_sp),                                          \
+            "m"(TACTL),                                             \
+            "m"(TACCR0),                                            \
+            "m"(isr_reti_latency),                                  \
+            "m"(ss_dbg_measuring_reti_latency)                      \
+            :                                                       \
+            );                                                      \
 }
 
 #endif

--- a/include/sancus_support/sancus_step.h
+++ b/include/sancus_support/sancus_step.h
@@ -9,58 +9,35 @@
 /* ======== SANCUS STEP DBG CONSTANTS ======== */
 #define RETI_LENGTH (0x5)
 #define JMP_LENGTH (0x2)
-#define RET_LENGTH (0x3)
-
-#define EXTRA_DELAY (0x2)
 
 #define INIT_LATENCY 1
 
-void sancus_step_print_latency(void);
-int sancus_step_get_latency(void);
+void __ss_print_latency(void);
+int __ss_get_latency(void);
 
 // sancus step interface
-void sancus_step_start(void);
-void sancus_step_init(void);
-void sancus_step_end(void);
+void __ss_start(void);
+void __ss_init(void);
+void __ss_end(void);
 
 // sancus step configuration parameters
-int ss_dbg_entry_delay;
-int ss_dbg_measuring_reti_latency;
-int isr_reti_latency;
-int sm_exit_latency;
-int isr_interrupted_sm;
+int __ss_dbg_entry_delay;
+int __ss_dbg_measuring_reti_latency;
+int __ss_isr_reti_latency;
+int __ss_sm_exit_latency;
+int __ss_isr_interrupted_sm;
 
 extern struct SancusModule ssdbg;
-int SM_ENTRY(ssdbg) ss_dbg_get_info(void);
+int SM_ENTRY(ssdbg) __ss_dbg_get_info(void);
 
 volatile int      __ss_isr_tar_entry;
-
-/*
-    if (isr_interrupted_sm)
-    {
-        if (ss_dbg_measuring_reti_latency)
-        {
-            TACTL = TACTL_DISABLE;
-            TACTL = TACTL_CONTINUOUS;
-        }
-        else
-        {
-            print_latency();
-            timer_irq(isr_reti_latency);
-        }
-    }
-    else
-    {
-        timer_disable();
-    }
-*/
 
 #define SANCUS_STEP_ISR_ENTRY(fct)                                  \
 __attribute__((naked)) __attribute__((interrupt(TIMER_IRQ_VECTOR))) \
 void timerA_isr_entry(void)                                         \
 {                                                                   \
     __asm__("mov &%0, &%2; save tar\n\t"                            \
-            "mov #0x4, &%4; disable timer\n\t "                     \
+            "mov %9, &%4; disable timer\n\t"                        \
             "mov #0x0, &%1\n\t"                                     \
             "cmp #0x0, r1\n\t"                                      \
             "jne 1f\n\t"                                            \
@@ -71,31 +48,34 @@ void timerA_isr_entry(void)                                         \
             "push #0x0\n\t"                                         \
             "cmp #0x0, &%7\n\t"                                     \
             "jz 2f\n\t"                                             \
-            "; measuring isr_reti_latency\n\t"                      \
-            "mov #0x220, &%4; set timer in continuous mode\n\t"     \
+            "; measuring __ss_isr_reti_latency\n\t"                 \
+            "mov %8, &%4; set timer in continuous mode\n\t"         \
             "jmp 3f\n\t"                                            \
-            "2: ; not measuring isr_reti_latency\n\t"               \
+            "2: ; not measuring __ss_isr_reti_latency\n\t"          \
             "call #" #fct "\n\t"                                    \
             "push r15\n\t"                                          \
             "mov &%6, r15\n\t"                                      \
             "add #0x5, r15 ;\n\t"                                   \
             "mov r15, &%5\n\t"                                      \
             "pop r15\n\t"                                           \
-            "mov #0x212, &%4; set timer in interrupt mode (irq)\n\t"\
+            "mov %10, &%4; set timer in interrupt mode (irq)\n\t"   \
             "jmp 3f\n\t"                                            \
             "1: ; sm not interrupted\n\t"                           \
-            "call #timer_disable\n\t"                               \
+            "mov %9, &%4; disable timer\n\t"                        \
             "3: reti\n\t"                                           \
             :                                                       \
             :                                                       \
             "m"(TAR),                                               \
-            "m"(isr_interrupted_sm),                                \
+            "m"(__ss_isr_interrupted_sm),                           \
             "m"(__ss_isr_tar_entry),                                \
             "m"(__isr_sp),                                          \
             "m"(TACTL),                                             \
             "m"(TACCR0),                                            \
-            "m"(isr_reti_latency),                                  \
-            "m"(ss_dbg_measuring_reti_latency)                      \
+            "m"(__ss_isr_reti_latency),                             \
+            "m"(__ss_dbg_measuring_reti_latency),                   \
+            "i"(TACTL_CONTINUOUS),                                  \
+            "i"(TACTL_DISABLE),                                     \
+            "i"(TACTL_ENABLE)                                       \
             :                                                       \
             );                                                      \
 }

--- a/include/sancus_support/sancus_step.h
+++ b/include/sancus_support/sancus_step.h
@@ -3,11 +3,17 @@
 #include <msp430.h>
 #include "timer.h"
 #include <stdint.h>
+#include <sancus/sm_support.h>
+
+
+/* ======== SANCUS STEP DBG CONSTANTS ======== */
+#define RETI_LENGTH 0x5
+#define SS_DBG_RECORD_DELAY 0x8
 
 // note the difference between the decimal and the hexadecimal constants
 #define HW_IRQ_LATENCY          34
 #define ISR_STACK_SIZE          512
-#define INIT_LATENCY            42
+#define INIT_LATENCY            0
 
 #define SANCUS_STEP_ISR(fct) \
     SANCUS_STEP_ISR_INTERNAL(fct, 0x42, 0x212)
@@ -15,11 +21,21 @@
 void print_latency(void);
 int get_latency(void);
 
-const int spy_IRQ_delay;
+// new interface
+void sancus_step_start(void);
+void sancus_step_init(void);
+void sancus_step_end(void);
+void sancus_step_isr_main(void);
+
+int ss_dbg_interrupted;
+int ss_dbg_entry_delay;
+int isr_latency;
+
+extern struct SancusModule ssdbg;
+int SM_ENTRY(ssdbg) ss_dbg_get_isr_latency(void);
 
 uint16_t __ss_isr_stack[ISR_STACK_SIZE];
 void*    __ss_isr_sp;
-void*    __ss_isr_reti_addr;
 volatile int      __ss_isr_tar_entry;
 
 /*
@@ -54,6 +70,5 @@ volatile int      __ss_isr_tar_entry;
             "2: ; cont after if-then-else               \n\t"   \
             "reti                                       \n\t"   \
             ::"m"(TAR),"m"(TACCR0),"m"(TACTL):);
-
 
 #endif

--- a/include/sancus_support/sancus_step.h
+++ b/include/sancus_support/sancus_step.h
@@ -10,6 +10,8 @@
 #define RETI_LENGTH (0x5)
 #define JMP_LENGTH (0x2)
 
+#define EXTRA_DELAY (0x2)
+
 #define INIT_LATENCY 1
 
 void __ss_print_latency(void);

--- a/include/sancus_support/sancus_step.h
+++ b/include/sancus_support/sancus_step.h
@@ -7,16 +7,13 @@
 
 
 /* ======== SANCUS STEP DBG CONSTANTS ======== */
-#define RETI_LENGTH 0x5
-#define SS_DBG_RECORD_DELAY 0x8
+#define RETI_LENGTH (0x5)
+#define JMP_LENGTH (0x2)
+#define RET_LENGTH (0x3)
 
-// note the difference between the decimal and the hexadecimal constants
-#define HW_IRQ_LATENCY          34
-#define ISR_STACK_SIZE          512
-#define INIT_LATENCY            0
+#define EXTRA_DELAY (0x2)
 
-#define SANCUS_STEP_ISR(fct) \
-    SANCUS_STEP_ISR_INTERNAL(fct, 0x42, 0x212)
+#define INIT_LATENCY 1
 
 void print_latency(void);
 int get_latency(void);
@@ -27,48 +24,35 @@ void sancus_step_init(void);
 void sancus_step_end(void);
 void sancus_step_isr_main(void);
 
-int ss_dbg_interrupted;
 int ss_dbg_entry_delay;
-int isr_latency;
+int ss_dbg_measuring_reti_latency;
+int isr_reti_latency;
+int sm_exit_latency;
+int isr_interrupted_sm;
 
 extern struct SancusModule ssdbg;
-int SM_ENTRY(ssdbg) ss_dbg_get_isr_latency(void);
+int SM_ENTRY(ssdbg) ss_dbg_get_info(void);
 
-uint16_t __ss_isr_stack[ISR_STACK_SIZE];
-void*    __ss_isr_sp;
 volatile int      __ss_isr_tar_entry;
 
-/*
- * The first latency will be useless, but this is ok for now.
- * We can fix this by adjusting the INIT_LATENCY definition.
- */
-#define SANCUS_STEP_INIT                    \
-    __asm__("dint\n\t");                    \
-    TACTL = TACTL_DISABLE;                  \
-    TACCR0 = INIT_LATENCY;                  \
-    /* source mclk, up mode */              \
-    TACTL = TACTL_ENABLE;
-
-/*
- * Execute fct after every instruction of the sancus module
- */
-#define SANCUS_STEP_ISR_INTERNAL(fct, sm_reti_val, ta_enable)   \
-    __asm__("mov &%0, &__ss_isr_tar_entry               \n\t"   \
-            "cmp #0x0, r1                               \n\t"   \
-            "jne 1f                                     \n\t"   \
-            "; sm got interrupted                       \n\t"   \
-            "mov &__ss_isr_sp, r1                       \n\t"   \
-            "push r15                                   \n\t"   \
-            "push #0x0                                  \n\t"   \
-            "call #" #fct "                             \n\t"   \
-            "mov #" #sm_reti_val ", &%1                 \n\t"   \
-            "mov #" #ta_enable ", &%2                   \n\t"   \
-            "jmp 2f                                     \n\t"   \
-            "1:                                         \n\t"   \
-            "; no sm interrupted                        \n\t"   \
-            "mov #0x4, &%2 ;disable timerA              \n\t"   \
-            "2: ; cont after if-then-else               \n\t"   \
-            "reti                                       \n\t"   \
-            ::"m"(TAR),"m"(TACCR0),"m"(TACTL):);
+#define SANCUS_STEP_ISR_ENTRY(fct)                                  \
+__attribute__((naked)) __attribute__((interrupt(TIMER_IRQ_VECTOR))) \
+void timerA_isr_entry(void)                                         \
+{                                                                   \
+    __asm__("mov &%0, &__ss_isr_tar_entry\n\t"                      \
+            "cmp #0x0, r1\n\t"                                      \
+            "jne 1f\n\t"                                            \
+            "; sm got interrupted\n\t"                              \
+            "mov #0x1, &isr_interrupted_sm\n\t"                     \
+            "jmp cont\n\t"                                          \
+            "1: mov #0x0, &isr_interrupted_sm\n\t"                  \
+            "cont:\n\t"                                             \
+            "mov &__isr_sp, r1\n\t"                                 \
+            "push r15\n\t"                                          \
+            "push #0x0\n\t"                                         \
+            "call #" #fct "\n\t"                                    \
+            "reti\n\t"                                              \
+            ::"m"(TAR):);                                           \
+}
 
 #endif

--- a/include/sancus_support/sancus_step.h
+++ b/include/sancus_support/sancus_step.h
@@ -10,7 +10,7 @@
 #define INIT_LATENCY            42
 
 #define SANCUS_STEP_ISR(fct) \
-    SANCUS_STEP_ISR_INTERNAL(fct, 0x41, 0x212)
+    SANCUS_STEP_ISR_INTERNAL(fct, 0x42, 0x212)
 
 void print_latency(void);
 int get_latency(void);

--- a/include/sancus_support/sancus_step.h
+++ b/include/sancus_support/sancus_step.h
@@ -4,9 +4,13 @@
 #include "timer.h"
 #include <stdint.h>
 
+// note the difference between the decimal and the hexadecimal constants
 #define HW_IRQ_LATENCY          34
 #define ISR_STACK_SIZE          512
 #define INIT_LATENCY            42
+
+#define SANCUS_STEP_ISR(fct) \
+    SANCUS_STEP_ISR_INTERNAL(fct, 0x41, 0x212)
 
 void print_latency(void);
 int get_latency(void);
@@ -30,7 +34,7 @@ volatile int      __ss_isr_tar_entry;
 /*
  * Execute fct after every instruction of the sancus module
  */
-#define SANCUS_STEP_ISR(fct)                                    \
+#define SANCUS_STEP_ISR_INTERNAL(fct, sm_reti_val, ta_enable)   \
     __asm__("mov &%0, &__ss_isr_tar_entry               \n\t"   \
             "cmp #0x0, r1                               \n\t"   \
             "jne 1f                                     \n\t"   \
@@ -39,8 +43,8 @@ volatile int      __ss_isr_tar_entry;
             "push r15                                   \n\t"   \
             "push #0x0                                  \n\t"   \
             "call #" #fct "                             \n\t"   \
-            "mov #0x41, &%1 ; 0x41 is latency of resume \n\t"   \
-            "mov #0x212, &%2 ; 0x212 is TACTL_ENABLE    \n\t"   \
+            "mov #" #sm_reti_val ", &%1                 \n\t"   \
+            "mov #" #ta_enable ", &%2                   \n\t"   \
             "jmp 2f                                     \n\t"   \
             "1:                                         \n\t"   \
             "; no sm interrupted                        \n\t"   \

--- a/include/sancus_support/sancus_step.h
+++ b/include/sancus_support/sancus_step.h
@@ -9,6 +9,7 @@
 #define INIT_LATENCY            42
 
 void print_latency(void);
+int get_latency(void);
 
 uint16_t __ss_isr_stack[ISR_STACK_SIZE];
 void*    __ss_isr_sp;

--- a/include/sancus_support/sancus_step.h
+++ b/include/sancus_support/sancus_step.h
@@ -15,6 +15,8 @@
 void print_latency(void);
 int get_latency(void);
 
+const int spy_IRQ_delay;
+
 uint16_t __ss_isr_stack[ISR_STACK_SIZE];
 void*    __ss_isr_sp;
 void*    __ss_isr_reti_addr;

--- a/include/sancus_support/sancus_step.h
+++ b/include/sancus_support/sancus_step.h
@@ -43,7 +43,7 @@ volatile int      __ss_isr_tar_entry;
             "jmp 2f                                     \n\t"   \
             "1:                                         \n\t"   \
             "; no sm interrupted                        \n\t"   \
-            "mov #0x0, &%2 ;disable timerA              \n\t"   \
+            "mov #0x4, &%2 ;disable timerA              \n\t"   \
             "2: ; cont after if-then-else               \n\t"   \
             "reti                                       \n\t"   \
             ::"m"(TAR),"m"(TACCR0),"m"(TACTL):);

--- a/include/sancus_support/timer.h
+++ b/include/sancus_support/timer.h
@@ -41,8 +41,34 @@ void timerA_isr_entry(void)                                         \
             "jne 1f\n\t"                                            \
             "mov &__isr_sp, r1\n\t"                                 \
             "push r15\n\t"                                          \
-            "push #0x0\n\t"                                         \
-            "1: call #" #fct "\n\t"                                 \
+            "push r2\n\t"                                           \
+            "1: push r15\n\t"                                       \
+            "push r14\n\t"                                          \
+            "push r13\n\t"                                          \
+            "push r12\n\t"                                          \
+            "push r11\n\t"                                          \
+            "push r10\n\t"                                          \
+            "push r9\n\t"                                           \
+            "push r8\n\t"                                           \
+            "push r7\n\t"                                           \
+            "push r6\n\t"                                           \
+            "push r5\n\t"                                           \
+            "push r4\n\t"                                           \
+            "push r3\n\t"                                           \
+            "call #" #fct "\n\t"                                    \
+            "pop r3\n\t"                                            \
+            "pop r4\n\t"                                            \
+            "pop r5\n\t"                                            \
+            "pop r6\n\t"                                            \
+            "pop r7\n\t"                                            \
+            "pop r8\n\t"                                            \
+            "pop r9\n\t"                                            \
+            "pop r10\n\t"                                           \
+            "pop r11\n\t"                                           \
+            "pop r12\n\t"                                           \
+            "pop r13\n\t"                                           \
+            "pop r14\n\t"                                           \
+            "pop r15\n\t"                                           \
             "reti\n\t"                                              \
             :::);                                                   \
 }

--- a/include/sancus_support/timer.h
+++ b/include/sancus_support/timer.h
@@ -37,10 +37,12 @@ __attribute__((naked)) __attribute__((interrupt(TIMER_IRQ_VECTOR))) \
 void timerA_isr_entry(void)                                         \
 {                                                                   \
     __asm__ __volatile__(                                           \
+            "cmp #0x0, r1\n\t"                                      \
+            "jne 1f\n\t"                                            \
             "mov &__isr_sp, r1\n\t"                                 \
             "push r15\n\t"                                          \
             "push #0x0\n\t"                                         \
-            "call #" #fct "\n\t"                                    \
+            "1: call #" #fct "\n\t"                                 \
             "reti\n\t"                                              \
             :::);                                                   \
 }

--- a/src/dev/timer.c
+++ b/src/dev/timer.c
@@ -1,5 +1,7 @@
 #include "timer.h"
 
+void* __isr_sp = (void*) &__isr_stack[ISR_STACK_SIZE-1];
+
 void timer_disable(void)
 {
     TACTL = TACTL_DISABLE;
@@ -17,7 +19,6 @@ void timer_irq(int interval)
 void timer_tsc_start(void)
 {
     TACTL = TACTL_DISABLE;
-    TACCR0 = 0x1;
     TACTL = TACTL_CONTINUOUS;
 }
 

--- a/src/sancus-step/sancus_step.c
+++ b/src/sancus-step/sancus_step.c
@@ -1,5 +1,6 @@
 #include "sancus_step.h"
 #include "timer.h"
+#include <stdio.h>
 
 void*    __ss_isr_sp = &__ss_isr_stack[ISR_STACK_SIZE-1];
 
@@ -8,4 +9,10 @@ void print_latency(void)
     TACTL = TACTL_DISABLE;
     int latency = __ss_isr_tar_entry - HW_IRQ_LATENCY - 1;
     printf("latency: %d\n", latency);
+}
+
+int get_latency(void)
+{
+    TACTL = TACTL_DISABLE;
+    return __ss_isr_tar_entry - HW_IRQ_LATENCY - 1;
 }

--- a/src/sancus-step/sancus_step.c
+++ b/src/sancus-step/sancus_step.c
@@ -16,3 +16,13 @@ int get_latency(void)
     TACTL = TACTL_DISABLE;
     return __ss_isr_tar_entry - HW_IRQ_LATENCY - 1;
 }
+
+/* ============TIMING MODULE===========*/
+void SM_ENTRY(spy) spy_enter(void)
+{
+    // Setup interrupt flag
+    __asm__("");
+    // Interrupt routine handles interrupt and resets timer
+    // Save timer value to spy_IRQ_delay upon entry
+    __asm__("mov &%0, &%1":"m"(spy_IRQ_delay):"m"(TAR):);
+}

--- a/src/sancus-step/sancus_step.c
+++ b/src/sancus-step/sancus_step.c
@@ -79,9 +79,9 @@ int SM_ENTRY(ssdbg) __ss_dbg_get_info(void)
     
     __asm__ __volatile__(
                 "mov &%0, &__ss_dbg_entry_delay\n\t"
-                "mov &%0, r15; irq should arrive here\n\t"
+                "mov &%0, r15; 1st irq should arrive here\n\t"
                 "mov %3, &%1\n\t"
-                "mov %2, &%1\n\t"
+                "mov %2, &%1; 2nd irq should arrive here\n\t"
                 "sub #0x1, r15\n\t"
                 "ret\n\t"
                 ::

--- a/src/sancus-step/sancus_step.c
+++ b/src/sancus-step/sancus_step.c
@@ -2,28 +2,29 @@
 #include "timer.h"
 #include <stdio.h>
 #include <sancus/sm_support.h>
-
-void* __ss_isr_sp = &__ss_isr_stack[ISR_STACK_SIZE-1];
+#include "sm_io.h"
 
 void print_latency(void)
 {
-    TACTL = TACTL_DISABLE;
-    int latency = __ss_isr_tar_entry - HW_IRQ_LATENCY - 1;
+    int latency = get_latency();
     printf("latency: %d\n", latency);
 }
 
 int get_latency(void)
 {
     TACTL = TACTL_DISABLE;
-    return __ss_isr_tar_entry - HW_IRQ_LATENCY - 1;
+    return __ss_isr_tar_entry - sm_exit_latency;
 }
 
 int ss_dbg_entry_delay = 0;
-int ss_dbg_interrupted = 0;
-int isr_latency = 0;
+int ss_dbg_measuring_reti_latency = 0;
+int isr_reti_latency = 0;
+int sm_exit_latency = 0;
+int isr_interrupted_sm = 0;
 
 /*
- * Determines isr_latency (reti into interrupted module)
+ * Determines isr_reti_latency (reti into interrupted module)
+ * and sm_exit_latency (from interrupt to isr)
  * and starts timer, so that nemesis can be executed
  */
 void sancus_step_start(void)
@@ -34,21 +35,37 @@ void sancus_step_start(void)
 }
 
 /*
- * Determines isr_latency (reti into interrupted moduled)
+ * Determines isr_reti_latency (reti into interrupted moduled)
+ * and sm_exit_latency (from interrupt to isr)
  */
 void sancus_step_init(void)
 {
-    ss_dbg_interrupted = 0;
+    sancus_enable(&ssdbg);
+    
+    ss_dbg_measuring_reti_latency = 1;
+    
     timer_tsc_start();
-    int isr_latency_t = ss_dbg_get_isr_latency();
+    ss_dbg_get_info();
+    
     timer_irq(ss_dbg_entry_delay);
-    isr_latency_t = ss_dbg_get_isr_latency();
+    int isr_reti_latency_t = ss_dbg_get_info();
     /* amount of cycles in the reti logic = measured delay
                                   - record delay
                                   - duration of reti instruction
                                   + 1 (because we count amount of cycles)
     */
-    isr_latency = isr_latency_t - SS_DBG_RECORD_DELAY - RETI_LENGTH + 1;
+    isr_reti_latency = isr_reti_latency_t
+                        - JMP_LENGTH
+                        - RET_LENGTH
+                        - RETI_LENGTH
+                        + 1;
+    
+    timer_irq(ss_dbg_entry_delay + EXTRA_DELAY);
+    ss_dbg_get_info();
+    sm_exit_latency = __ss_isr_tar_entry - 3;
+    printf("%d, %d, %d\n", isr_reti_latency, sm_exit_latency, ss_dbg_entry_delay);
+    
+    ss_dbg_measuring_reti_latency = 0;
 }
 
 void sancus_step_end(void)
@@ -56,22 +73,80 @@ void sancus_step_end(void)
     TACTL = TACTL_DISABLE;
 }
 
+__attribute__((naked))
 void sancus_step_isr_main(void)
 {
-    
+    __asm__ __volatile__(
+        "cmp #0x0, &%2\n\t"
+        "jz 1f\n\t"
+        ";sm interrupted\n\t"
+        "cmp #0x0, &%3\n\t"
+        "jz 3f\n\t"
+        "; measuring isr_reti_latency\n\t"
+        "mov #0x4, &%0\n\t"
+        "mov #0x220, &%0\n\t"
+        "jmp 2f\n\t"
+        "3: ; not measuring isr_reti_latency\n\t"
+        "call #print_latency\n\t"
+        "mov #0x4, &%0\n\t"
+        "push r15\n\t"
+        "mov &%4, r15\n\t"
+        "add #0x8, r15 ;\n\t"
+        "mov r15, &%1\n\t"
+        "pop r15\n\t"
+        "mov #0x212, &%0\n\t"
+        "jmp 2f\n\t"
+        "1: ; sm not interrupted\n\t"
+        "call #timer_disable\n\t"
+        "2: ret\n\t"
+        :
+        :
+        "m"(TACTL),
+        "m"(TACCR0),
+        "m"(isr_interrupted_sm),
+        "m"(ss_dbg_measuring_reti_latency),
+        "m"(isr_reti_latency));
+    /*
+    if (isr_interrupted_sm)
+    {
+        if (ss_dbg_measuring_reti_latency)
+        {
+            TACTL = TACTL_DISABLE;
+            TACTL = TACTL_CONTINUOUS;
+        }
+        else
+        {
+            print_latency();
+            timer_irq(isr_reti_latency);
+        }
+    }
+    else
+    {
+        timer_disable();
+    }
+    */
 }
 
 DECLARE_SM(ssdbg, 0x1234);
 
-int SM_ENTRY(ssdbg) ss_dbg_get_isr_latency(void)
+__attribute__((naked))
+int SM_ENTRY(ssdbg) ss_dbg_get_info(void)
 {
+    /*
     ss_dbg_entry_delay = TAR;
-    if (!ss_dbg_interrupted)
-    {
-        return 0;
-    }
-    else
-    {
-        return TAR;
-    }
+    int rv = TAR;
+    TACTL = TACTL_DISABLE;
+    TACTL = TACTL_CONTINUOUS;
+    return rv;
+    */
+    
+    __asm__ __volatile__(
+                "mov &%0, &ss_dbg_entry_delay\n\t"
+                "mov &%0, r15\n\t"
+                "mov #0x4, &%1\n\t"
+                "mov #0x220, &%1\n\t"
+                "sub #0x1, r15\n\t"
+                "ret\n\t"
+                ::"m"(TAR), "m"(TACTL):
+                );
 }

--- a/src/sancus-step/sancus_step.c
+++ b/src/sancus-step/sancus_step.c
@@ -1,8 +1,9 @@
 #include "sancus_step.h"
 #include "timer.h"
 #include <stdio.h>
+#include <sancus/sm_support.h>
 
-void*    __ss_isr_sp = &__ss_isr_stack[ISR_STACK_SIZE-1];
+void* __ss_isr_sp = &__ss_isr_stack[ISR_STACK_SIZE-1];
 
 void print_latency(void)
 {
@@ -17,12 +18,60 @@ int get_latency(void)
     return __ss_isr_tar_entry - HW_IRQ_LATENCY - 1;
 }
 
-/* ============TIMING MODULE===========*/
-void SM_ENTRY(spy) spy_enter(void)
+int ss_dbg_entry_delay = 0;
+int ss_dbg_interrupted = 0;
+int isr_latency = 0;
+
+/*
+ * Determines isr_latency (reti into interrupted module)
+ * and starts timer, so that nemesis can be executed
+ */
+void sancus_step_start(void)
 {
-    // Setup interrupt flag
-    __asm__("");
-    // Interrupt routine handles interrupt and resets timer
-    // Save timer value to spy_IRQ_delay upon entry
-    __asm__("mov &%0, &%1":"m"(spy_IRQ_delay):"m"(TAR):);
+    sancus_step_init();
+    __asm__("dint\n\t");
+    timer_irq(INIT_LATENCY);
+}
+
+/*
+ * Determines isr_latency (reti into interrupted moduled)
+ */
+void sancus_step_init(void)
+{
+    ss_dbg_interrupted = 0;
+    timer_tsc_start();
+    int isr_latency_t = ss_dbg_get_isr_latency();
+    timer_irq(ss_dbg_entry_delay);
+    isr_latency_t = ss_dbg_get_isr_latency();
+    /* amount of cycles in the reti logic = measured delay
+                                  - record delay
+                                  - duration of reti instruction
+                                  + 1 (because we count amount of cycles)
+    */
+    isr_latency = isr_latency_t - SS_DBG_RECORD_DELAY - RETI_LENGTH + 1;
+}
+
+void sancus_step_end(void)
+{
+    TACTL = TACTL_DISABLE;
+}
+
+void sancus_step_isr_main(void)
+{
+    
+}
+
+DECLARE_SM(ssdbg, 0x1234);
+
+int SM_ENTRY(ssdbg) ss_dbg_get_isr_latency(void)
+{
+    ss_dbg_entry_delay = TAR;
+    if (!ss_dbg_interrupted)
+    {
+        return 0;
+    }
+    else
+    {
+        return TAR;
+    }
 }


### PR DESCRIPTION
Sancus-step now includes a debug module for automatic configuration of nemesis parameters, such as isr_reti_latency (latency between the end of the reti instruction and the first new instruction executed by the module) and sm_exit_latency (the latency between the arrival of an interrupt and the execution of the isr)