### PR TITLE
Extending timer and Sancus-Step libraries

### DIFF
--- a/include/sancus_support/sancus_step.h
+++ b/include/sancus_support/sancus_step.h
@@ -35,7 +35,7 @@ int SM_ENTRY(ssdbg) __ss_dbg_get_info(void);
 
 volatile int      __ss_isr_tar_entry;
 
-#define SANCUS_STEP_ISR_ENTRY(fct)                                  \
+#define SANCUS_STEP_ISR_ENTRY(fct_single_step, fct_end)             \
 __attribute__((naked)) __attribute__((interrupt(TIMER_IRQ_VECTOR))) \
 void timerA_isr_entry(void)                                         \
 {                                                                   \
@@ -55,7 +55,7 @@ void timerA_isr_entry(void)                                         \
             "mov %8, &%4; set timer in continuous mode\n\t"         \
             "jmp 3f\n\t"                                            \
             "2: ; not measuring __ss_isr_reti_latency\n\t"          \
-            "call #" #fct "\n\t"                                    \
+            "call #" #fct_single_step "\n\t"                        \
             "push r15\n\t"                                          \
             "mov &%6, r15\n\t"                                      \
             "add #0x5, r15 ;\n\t"                                   \
@@ -66,6 +66,7 @@ void timerA_isr_entry(void)                                         \
             "jmp 3f\n\t"                                            \
             "1: ; sm not interrupted\n\t"                           \
             "mov %9, &%4; disable timer\n\t"                        \
+            "call #" #fct_end "\n\t"                                \
             "3: reti\n\t"                                           \
             :                                                       \
             :                                                       \
@@ -87,7 +88,7 @@ void timerA_isr_entry(void)                                         \
             );                                                      \
 }
 
-#define SANCUS_STEP_ISR_ENTRY2(fct)                                 \
+#define SANCUS_STEP_ISR_ENTRY2(fct_single_step, fct_end)            \
 __attribute__((naked)) __attribute__((interrupt(TIMER_IRQ_VECTOR2)))\
 void timerA_isr_entry2(void)                                        \
 {                                                                   \
@@ -108,7 +109,7 @@ void timerA_isr_entry2(void)                                        \
             "mov %8, &%4; set timer in continuous mode\n\t"         \
             "jmp 3f\n\t"                                            \
             "2: ; not measuring __ss_isr_reti_latency\n\t"          \
-            "call #" #fct "\n\t"                                    \
+            "call #" #fct_single_step "\n\t"                        \
             "push r15\n\t"                                          \
             "mov &%6, r15\n\t"                                      \
             "add #0x6, r15 ;\n\t"                                   \
@@ -119,6 +120,7 @@ void timerA_isr_entry2(void)                                        \
             "jmp 3f\n\t"                                            \
             "1: ; sm not interrupted\n\t"                           \
             "mov %9, &%4; disable timer\n\t"                        \
+            "call #" #fct_end "\n\t"                                \
             "3: reti\n\t"                                           \
             :                                                       \
             :                                                       \

--- a/include/sancus_support/sancus_step.h
+++ b/include/sancus_support/sancus_step.h
@@ -61,7 +61,8 @@ void timerA_isr_entry(void)                                         \
             "add #0x5, r15 ;\n\t"                                   \
             "mov r15, &%5\n\t"                                      \
             "pop r15\n\t"                                           \
-            "mov %10, &%4; set timer in interrupt mode (irq)\n\t"   \
+            "mov %11, &%12; set timer in interrupt mode (irqc)\n\t" \
+            "mov %13, &%4; set timer in interrupt mode 2 (irqc)\n\t"\
             "jmp 3f\n\t"                                            \
             "1: ; sm not interrupted\n\t"                           \
             "mov %9, &%4; disable timer\n\t"                        \
@@ -78,7 +79,63 @@ void timerA_isr_entry(void)                                         \
             "m"(__ss_dbg_measuring_reti_latency),                   \
             "i"(TACTL_CONTINUOUS),                                  \
             "i"(TACTL_DISABLE),                                     \
-            "i"(TACTL_ENABLE)                                       \
+            "i"(TACTL_ENABLE),                                      \
+            "i"(TACCTL_ENABLE_CONT),                                \
+            "m"(TACCTL0),                                           \
+            "i"(TACTL_ENABLE_CONT)                                  \
+            :                                                       \
+            );                                                      \
+}
+
+#define SANCUS_STEP_ISR_ENTRY2(fct)                                 \
+__attribute__((naked)) __attribute__((interrupt(TIMER_IRQ_VECTOR2)))\
+void timerA_isr_entry2(void)                                        \
+{                                                                   \
+    __asm__("mov &%0, &%2; save tar\n\t"                            \
+            "mov %9, &%4; disable timer\n\t"                        \
+            "sub &%5, &%2; subtract TACCR0 from timestamp\n\t"      \
+            "mov #0x0, &%1\n\t"                                     \
+            "cmp #0x0, r1\n\t"                                      \
+            "jne 1f\n\t"                                            \
+            "; sm got interrupted\n\t"                              \
+            "mov #0x1, &%1\n\t"                                     \
+            "mov &%3, r1\n\t"                                       \
+            "push r15\n\t"                                          \
+            "push #0x0\n\t"                                         \
+            "cmp #0x0, &%7\n\t"                                     \
+            "jz 2f\n\t"                                             \
+            "; measuring __ss_isr_reti_latency\n\t"                 \
+            "mov %8, &%4; set timer in continuous mode\n\t"         \
+            "jmp 3f\n\t"                                            \
+            "2: ; not measuring __ss_isr_reti_latency\n\t"          \
+            "call #" #fct "\n\t"                                    \
+            "push r15\n\t"                                          \
+            "mov &%6, r15\n\t"                                      \
+            "add #0x6, r15 ;\n\t"                                   \
+            "mov r15, &%5\n\t"                                      \
+            "pop r15\n\t"                                           \
+            "mov %11, &%12; set timer in interrupt mode (irqc)\n\t" \
+            "mov %13, &%4; set timer in interrupt mode 2 (irqc)\n\t"\
+            "jmp 3f\n\t"                                            \
+            "1: ; sm not interrupted\n\t"                           \
+            "mov %9, &%4; disable timer\n\t"                        \
+            "3: reti\n\t"                                           \
+            :                                                       \
+            :                                                       \
+            "m"(TAR),                                               \
+            "m"(__ss_isr_interrupted_sm),                           \
+            "m"(__ss_isr_tar_entry),                                \
+            "m"(__isr_sp),                                          \
+            "m"(TACTL),                                             \
+            "m"(TACCR0),                                            \
+            "m"(__ss_isr_reti_latency),                             \
+            "m"(__ss_dbg_measuring_reti_latency),                   \
+            "i"(TACTL_CONTINUOUS),                                  \
+            "i"(TACTL_DISABLE),                                     \
+            "i"(TACTL_ENABLE),                                      \
+            "i"(TACCTL_ENABLE_CONT),                                \
+            "m"(TACCTL0),                                           \
+            "i"(TACTL_ENABLE_CONT)                                  \
             :                                                       \
             );                                                      \
 }

--- a/include/sancus_support/timer.h
+++ b/include/sancus_support/timer.h
@@ -6,8 +6,12 @@
 #define TACTL_DISABLE       (TACLR) // 0x04
 #define TACTL_ENABLE        (TASSEL_2 + MC_1 + TAIE) // 0x212
 #define TACTL_CONTINUOUS    ((TASSEL_2 + MC_2) & ~TAIE) // 0x220
+#define TACTL_ENABLE_CONT   (TASSEL_2 + MC_2 + TAIE)
+#define TACCTL_ENABLE_CONT  (CM_1 + CCIS_0 + SCS + CCIE)
+#define TACCTL_DISABLE      (0)
 
 #define TIMER_IRQ_VECTOR    16 /* IRQ number 8 */
+#define TIMER_IRQ_VECTOR2   18 /* IRQ number 9 */
 
 #define ISR_STACK_SIZE (512)
 
@@ -21,6 +25,12 @@ void timer_disable(void);
  * register will continue counting from zero after IRQ generation.
  */
 void timer_irq(int interval);
+
+/*
+ * Fire an IRQ after the specified number of cycles have elapsed. Timer_A TAR
+ * register will continue counting from interval after IRQ generation.
+ */
+void timer_irqc(int interval);
 
 /*
  * Operate Timer_A in continuous mode to act like a Time Stamp Counter.
@@ -73,5 +83,45 @@ void timerA_isr_entry(void)                                         \
             :::);                                                   \
 }
 
+#define TIMER_ISR_ENTRY2(fct)                                       \
+__attribute__((naked)) __attribute__((interrupt(TIMER_IRQ_VECTOR2)))\
+void timerA_isr_entry2(void)                                        \
+{                                                                   \
+    __asm__ __volatile__(                                           \
+            "cmp #0x0, r1\n\t"                                      \
+            "jne 1f\n\t"                                            \
+            "mov &__isr_sp, r1\n\t"                                 \
+            "push r15\n\t"                                          \
+            "push r2\n\t"                                           \
+            "1: push r15\n\t"                                       \
+            "push r14\n\t"                                          \
+            "push r13\n\t"                                          \
+            "push r12\n\t"                                          \
+            "push r11\n\t"                                          \
+            "push r10\n\t"                                          \
+            "push r9\n\t"                                           \
+            "push r8\n\t"                                           \
+            "push r7\n\t"                                           \
+            "push r6\n\t"                                           \
+            "push r5\n\t"                                           \
+            "push r4\n\t"                                           \
+            "push r3\n\t"                                           \
+            "call #" #fct "\n\t"                                    \
+            "pop r3\n\t"                                            \
+            "pop r4\n\t"                                            \
+            "pop r5\n\t"                                            \
+            "pop r6\n\t"                                            \
+            "pop r7\n\t"                                            \
+            "pop r8\n\t"                                            \
+            "pop r9\n\t"                                            \
+            "pop r10\n\t"                                           \
+            "pop r11\n\t"                                           \
+            "pop r12\n\t"                                           \
+            "pop r13\n\t"                                           \
+            "pop r14\n\t"                                           \
+            "pop r15\n\t"                                           \
+            "reti\n\t"                                              \
+            :::);                                                   \
+}
 
 #endif

--- a/src/dev/timer.c
+++ b/src/dev/timer.c
@@ -12,13 +12,24 @@ void timer_irq(int interval)
     TACTL = TACTL_DISABLE;
     /* 1 cycle overhead TACTL write */
     TACCR0 = interval - 1;
+    TACCTL0 = TACCTL_DISABLE;
     /* source mclk, up mode */
     TACTL = TACTL_ENABLE;
+}
+
+void timer_irqc(int interval)
+{
+    TACTL = TACTL_DISABLE;
+    TACCR0 = interval;
+    TACCTL0 = TACCTL_ENABLE_CONT;
+    TACTL = TACTL_CONTINUOUS;
 }
 
 void timer_tsc_start(void)
 {
     TACTL = TACTL_DISABLE;
+    TACCR0 = 0;
+    TACCTL0 = TACCTL_DISABLE;
     TACTL = TACTL_CONTINUOUS;
 }
 

--- a/src/sancus-step/sancus_step.c
+++ b/src/sancus-step/sancus_step.c
@@ -46,7 +46,7 @@ void __ss_init(void)
     timer_tsc_start();
     __ss_dbg_get_info();
     
-    timer_irq(__ss_dbg_entry_delay);
+    timer_irqc(__ss_dbg_entry_delay);
     int isr_reti_latency_t = __ss_dbg_get_info();
     /* amount of cycles in the reti logic = measured delay
                                   - record delay
@@ -58,10 +58,12 @@ void __ss_init(void)
                         - RETI_LENGTH
                         + 1;
     
-    timer_irq(__ss_dbg_entry_delay + EXTRA_DELAY);
+    timer_irqc(__ss_dbg_entry_delay + EXTRA_DELAY);
     __ss_dbg_get_info();
     __ss_sm_exit_latency = __ss_isr_tar_entry - ENTRY_DELAY;
-    printf("%d, %d, %d\n", __ss_isr_reti_latency, __ss_sm_exit_latency, __ss_dbg_entry_delay);
+    printf("resume latency: %d\n", __ss_isr_reti_latency);
+    printf("exit latency: %d\n", __ss_sm_exit_latency);
+    printf("entry delay: %d\n", __ss_dbg_entry_delay);
     
     __ss_dbg_measuring_reti_latency = 0;
 }


### PR DESCRIPTION
Added support for interrupts in continuous mode (i.e. the timer will keep counting instead of resetting to 0).
This allows Sancus-Step to measure interrupt latencies of Sancus hardware instructions such as the crypto ones. Otherwise, if a timer in up mode is used (i.e. timer resets to 0 on interrupt), the Sancus crypto instruction will be longer than the max value of the timer, so only an instruction latency module the timer period will be measured.