### PR TITLE
Enable consecutive sancus-step runs

### DIFF
--- a/include/sancus_support/sancus_step.h
+++ b/include/sancus_support/sancus_step.h
@@ -48,17 +48,17 @@ void timerA_isr_entry2(void)                                                   \
         "sub &%5, &%2\n\t"                                                     \
         /* __ss_isr_interrupted_sm = false */                                  \
         "mov #0x0, &%1\n\t"                                                    \
-        /* check whether r1 register is set (0 if module got interrupted?) */  \
+        /* check whether r1 register is set (0 if module got interrupted) */   \
         "cmp #0x0, r1\n\t"                                                     \
-        /* if module was not interrupted, jump to label "1" */                 \
+        /* if module was not interrupted, jump to label "1" (call end fn) */   \
         "jne 1f\n\t"                                                           \
         /* __ss_isr_interrupted_sm = true */                                   \
         "mov #0x1, &%1\n\t"                                                    \
         /* r1 = __isr_sp */                                                    \
         "mov &%3, r1\n\t"                                                      \
-        /*  */                                                                 \
+        /* push r15 to stack */                                                \
         "push r15\n\t"                                                         \
-        /*  */                                                                 \
+        /* push 0 to stack */                                                  \
         "push #0x0\n\t"                                                        \
         /* check whether __ss_dbg_measuring_reti_latency is set */             \
         "cmp #0x0, &%7\n\t"                                                    \
@@ -72,7 +72,7 @@ void timerA_isr_entry2(void)                                                   \
         "2: \n\t"                                                              \
         /* call the first function parameter */                                \
         "call #" #fct_single_step "\n\t"                                       \
-        /*  */                                                                 \
+        /* push r15 to stack */                                                \
         "push r15\n\t"                                                         \
         /* r15 = __ss_isr_reti_latency */                                      \
         "mov &%6, r15\n\t"                                                     \
@@ -80,7 +80,7 @@ void timerA_isr_entry2(void)                                                   \
         "add #0x6, r15 ;\n\t"                                                  \
         /* TACCR0 = r15 */                                                     \
         "mov r15, &%5\n\t"                                                     \
-        /*  */                                                                 \
+        /* pop the stack top to r15 */                                         \
         "pop r15\n\t"                                                          \
         /* TACCTL0 = TACCTL_ENABLE_CONT */                                     \
         "mov %11, &%12\n\t"                                                    \

--- a/include/sancus_support/sancus_step.h
+++ b/include/sancus_support/sancus_step.h
@@ -20,7 +20,6 @@ int __ss_get_latency(void);
 
 // sancus step interface
 void __ss_start(void);
-void __ss_init(void);
 void __ss_end(void);
 
 // sancus step configuration parameters

--- a/include/sancus_support/sancus_step.h
+++ b/include/sancus_support/sancus_step.h
@@ -35,59 +35,6 @@ int SM_ENTRY(ssdbg) __ss_dbg_get_info(void);
 
 volatile int      __ss_isr_tar_entry;
 
-#define SANCUS_STEP_ISR_ENTRY(fct_single_step, fct_end)             \
-__attribute__((naked)) __attribute__((interrupt(TIMER_IRQ_VECTOR))) \
-void timerA_isr_entry(void)                                         \
-{                                                                   \
-    __asm__("mov &%0, &%2; save tar\n\t"                            \
-            "mov %9, &%4; disable timer\n\t"                        \
-            "mov #0x0, &%1\n\t"                                     \
-            "cmp #0x0, r1\n\t"                                      \
-            "jne 1f\n\t"                                            \
-            "; sm got interrupted\n\t"                              \
-            "mov #0x1, &%1\n\t"                                     \
-            "mov &%3, r1\n\t"                                       \
-            "push r15\n\t"                                          \
-            "push #0x0\n\t"                                         \
-            "cmp #0x0, &%7\n\t"                                     \
-            "jz 2f\n\t"                                             \
-            "; measuring __ss_isr_reti_latency\n\t"                 \
-            "mov %8, &%4; set timer in continuous mode\n\t"         \
-            "jmp 3f\n\t"                                            \
-            "2: ; not measuring __ss_isr_reti_latency\n\t"          \
-            "call #" #fct_single_step "\n\t"                        \
-            "push r15\n\t"                                          \
-            "mov &%6, r15\n\t"                                      \
-            "add #0x5, r15 ;\n\t"                                   \
-            "mov r15, &%5\n\t"                                      \
-            "pop r15\n\t"                                           \
-            "mov %11, &%12; set timer in interrupt mode (irqc)\n\t" \
-            "mov %13, &%4; set timer in interrupt mode 2 (irqc)\n\t"\
-            "jmp 3f\n\t"                                            \
-            "1: ; sm not interrupted\n\t"                           \
-            "mov %9, &%4; disable timer\n\t"                        \
-            "call #" #fct_end "\n\t"                                \
-            "3: reti\n\t"                                           \
-            :                                                       \
-            :                                                       \
-            "m"(TAR),                                               \
-            "m"(__ss_isr_interrupted_sm),                           \
-            "m"(__ss_isr_tar_entry),                                \
-            "m"(__isr_sp),                                          \
-            "m"(TACTL),                                             \
-            "m"(TACCR0),                                            \
-            "m"(__ss_isr_reti_latency),                             \
-            "m"(__ss_dbg_measuring_reti_latency),                   \
-            "i"(TACTL_CONTINUOUS),                                  \
-            "i"(TACTL_DISABLE),                                     \
-            "i"(TACTL_ENABLE),                                      \
-            "i"(TACCTL_ENABLE_CONT),                                \
-            "m"(TACCTL0),                                           \
-            "i"(TACTL_ENABLE_CONT)                                  \
-            :                                                       \
-            );                                                      \
-}
-
 #define SANCUS_STEP_ISR_ENTRY2(fct_single_step, fct_end)            \
 __attribute__((naked)) __attribute__((interrupt(TIMER_IRQ_VECTOR2)))\
 void timerA_isr_entry2(void)                                        \
@@ -124,20 +71,20 @@ void timerA_isr_entry2(void)                                        \
             "3: reti\n\t"                                           \
             :                                                       \
             :                                                       \
-            "m"(TAR),                                               \
-            "m"(__ss_isr_interrupted_sm),                           \
-            "m"(__ss_isr_tar_entry),                                \
-            "m"(__isr_sp),                                          \
-            "m"(TACTL),                                             \
-            "m"(TACCR0),                                            \
-            "m"(__ss_isr_reti_latency),                             \
-            "m"(__ss_dbg_measuring_reti_latency),                   \
-            "i"(TACTL_CONTINUOUS),                                  \
-            "i"(TACTL_DISABLE),                                     \
-            "i"(TACTL_ENABLE),                                      \
-            "i"(TACCTL_ENABLE_CONT),                                \
-            "m"(TACCTL0),                                           \
-            "i"(TACTL_ENABLE_CONT)                                  \
+            "m"(TAR),                                  /* %0 */     \
+            "m"(__ss_isr_interrupted_sm),              /* %1 */     \
+            "m"(__ss_isr_tar_entry),                   /* %2 */     \
+            "m"(__isr_sp),                             /* %3 */     \
+            "m"(TACTL),                                /* %4 */     \
+            "m"(TACCR0),                               /* %5 */     \
+            "m"(__ss_isr_reti_latency),                /* %6 */     \
+            "m"(__ss_dbg_measuring_reti_latency),      /* %7 */     \
+            "i"(TACTL_CONTINUOUS),                     /* %8 */     \
+            "i"(TACTL_DISABLE),                        /* %9 */     \
+            "i"(TACTL_ENABLE),                         /* %10 */    \
+            "i"(TACCTL_ENABLE_CONT),                   /* %11 */    \
+            "m"(TACCTL0),                              /* %12 */    \
+            "i"(TACTL_ENABLE_CONT)                     /* %13 */    \
             :                                                       \
             );                                                      \
 }

--- a/include/sancus_support/sancus_step.h
+++ b/include/sancus_support/sancus_step.h
@@ -33,60 +33,87 @@ int __ss_isr_interrupted_sm;
 extern struct SancusModule ssdbg;
 int SM_ENTRY(ssdbg) __ss_dbg_get_info(void);
 
-volatile int      __ss_isr_tar_entry;
+volatile int __ss_isr_tar_entry;
 
-#define SANCUS_STEP_ISR_ENTRY2(fct_single_step, fct_end)            \
-__attribute__((naked)) __attribute__((interrupt(TIMER_IRQ_VECTOR2)))\
-void timerA_isr_entry2(void)                                        \
-{                                                                   \
-    __asm__("mov &%0, &%2; save tar\n\t"                            \
-            "mov %9, &%4; disable timer\n\t"                        \
-            "sub &%5, &%2; subtract TACCR0 from timestamp\n\t"      \
-            "mov #0x0, &%1\n\t"                                     \
-            "cmp #0x0, r1\n\t"                                      \
-            "jne 1f\n\t"                                            \
-            "; sm got interrupted\n\t"                              \
-            "mov #0x1, &%1\n\t"                                     \
-            "mov &%3, r1\n\t"                                       \
-            "push r15\n\t"                                          \
-            "push #0x0\n\t"                                         \
-            "cmp #0x0, &%7\n\t"                                     \
-            "jz 2f\n\t"                                             \
-            "; measuring __ss_isr_reti_latency\n\t"                 \
-            "mov %8, &%4; set timer in continuous mode\n\t"         \
-            "jmp 3f\n\t"                                            \
-            "2: ; not measuring __ss_isr_reti_latency\n\t"          \
-            "call #" #fct_single_step "\n\t"                        \
-            "push r15\n\t"                                          \
-            "mov &%6, r15\n\t"                                      \
-            "add #0x6, r15 ;\n\t"                                   \
-            "mov r15, &%5\n\t"                                      \
-            "pop r15\n\t"                                           \
-            "mov %11, &%12; set timer in interrupt mode (irqc)\n\t" \
-            "mov %13, &%4; set timer in interrupt mode 2 (irqc)\n\t"\
-            "jmp 3f\n\t"                                            \
-            "1: ; sm not interrupted\n\t"                           \
-            "mov %9, &%4; disable timer\n\t"                        \
-            "call #" #fct_end "\n\t"                                \
-            "3: reti\n\t"                                           \
-            :                                                       \
-            :                                                       \
-            "m"(TAR),                                  /* %0 */     \
-            "m"(__ss_isr_interrupted_sm),              /* %1 */     \
-            "m"(__ss_isr_tar_entry),                   /* %2 */     \
-            "m"(__isr_sp),                             /* %3 */     \
-            "m"(TACTL),                                /* %4 */     \
-            "m"(TACCR0),                               /* %5 */     \
-            "m"(__ss_isr_reti_latency),                /* %6 */     \
-            "m"(__ss_dbg_measuring_reti_latency),      /* %7 */     \
-            "i"(TACTL_CONTINUOUS),                     /* %8 */     \
-            "i"(TACTL_DISABLE),                        /* %9 */     \
-            "i"(TACTL_ENABLE),                         /* %10 */    \
-            "i"(TACCTL_ENABLE_CONT),                   /* %11 */    \
-            "m"(TACCTL0),                              /* %12 */    \
-            "i"(TACTL_ENABLE_CONT)                     /* %13 */    \
-            :                                                       \
-            );                                                      \
+#define SANCUS_STEP_ISR_ENTRY2(fct_single_step, fct_end)                       \
+__attribute__((naked)) __attribute__((interrupt(TIMER_IRQ_VECTOR2)))           \
+void timerA_isr_entry2(void)                                                   \
+{                                                                              \
+    __asm__(                                                                   \
+        /* copy TAR value to __ss_isr_tar_entry */                             \
+        "mov &%0, &%2\n\t"                                                     \
+        /* disable timer (copy TACTL_DISABLE to TACTL) */                      \
+        "mov %9, &%4\n\t"                                                      \
+        /* subtract TACCR0 from __ss_isr_tar_entry */                          \
+        "sub &%5, &%2\n\t"                                                     \
+        /* __ss_isr_interrupted_sm = false */                                  \
+        "mov #0x0, &%1\n\t"                                                    \
+        /* check whether r1 register is set (0 if module got interrupted?) */  \
+        "cmp #0x0, r1\n\t"                                                     \
+        /* if module was not interrupted, jump to label "1" */                 \
+        "jne 1f\n\t"                                                           \
+        /* __ss_isr_interrupted_sm = true */                                   \
+        "mov #0x1, &%1\n\t"                                                    \
+        /* r1 = __isr_sp */                                                    \
+        "mov &%3, r1\n\t"                                                      \
+        /*  */                                                                 \
+        "push r15\n\t"                                                         \
+        /*  */                                                                 \
+        "push #0x0\n\t"                                                        \
+        /* check whether __ss_dbg_measuring_reti_latency is set */             \
+        "cmp #0x0, &%7\n\t"                                                    \
+        /* if not, jump to label "2" */                                        \
+        "jz 2f\n\t"                                                            \
+        /* TACTL = TACTL_CONTINUOUS */                                         \
+        "mov %8, &%4\n\t"                                                      \
+        /* jump to label "3" */                                                \
+        "jmp 3f\n\t"                                                           \
+        /* label 2: not measuring __ss_isr_reti_latency */                     \
+        "2: \n\t"                                                              \
+        /* call the first function parameter */                                \
+        "call #" #fct_single_step "\n\t"                                       \
+        /*  */                                                                 \
+        "push r15\n\t"                                                         \
+        /* r15 = __ss_isr_reti_latency */                                      \
+        "mov &%6, r15\n\t"                                                     \
+        /* r15 += 6 */                                                         \
+        "add #0x6, r15 ;\n\t"                                                  \
+        /* TACCR0 = r15 */                                                     \
+        "mov r15, &%5\n\t"                                                     \
+        /*  */                                                                 \
+        "pop r15\n\t"                                                          \
+        /* TACCTL0 = TACCTL_ENABLE_CONT */                                     \
+        "mov %11, &%12\n\t"                                                    \
+        /* TACTL = TACTL_ENABLE_CONT */                                        \
+        "mov %13, &%4\n\t"                                                     \
+        /* jump to return instruction */                                       \
+        "jmp 3f\n\t"                                                           \
+        /* label 1: module was not interrupted */                              \
+        "1: \n\t"                                                              \
+        /* TACTL = TACTL_DISABLE */                                            \
+        "mov %9, &%4; disable timer\n\t"                                       \
+        /* call the second function parameter */                               \
+        "call #" #fct_end "\n\t"                                               \
+        /* return from the ISR */                                              \
+        "3: reti\n\t"                                                          \
+        :                                                                      \
+        :                                                                      \
+        "m"(TAR),                                                    /* %0 */  \
+        "m"(__ss_isr_interrupted_sm),                                /* %1 */  \
+        "m"(__ss_isr_tar_entry),                                     /* %2 */  \
+        "m"(__isr_sp),                                               /* %3 */  \
+        "m"(TACTL),                                                  /* %4 */  \
+        "m"(TACCR0),                                                 /* %5 */  \
+        "m"(__ss_isr_reti_latency),                                  /* %6 */  \
+        "m"(__ss_dbg_measuring_reti_latency),                        /* %7 */  \
+        "i"(TACTL_CONTINUOUS),                                       /* %8 */  \
+        "i"(TACTL_DISABLE),                                          /* %9 */  \
+        "i"(TACTL_ENABLE),                                           /* %10 */ \
+        "i"(TACCTL_ENABLE_CONT),                                     /* %11 */ \
+        "m"(TACCTL0),                                                /* %12 */ \
+        "i"(TACTL_ENABLE_CONT)                                       /* %13 */ \
+        :                                                                      \
+    );                                                                         \
 }
 
 #endif

--- a/include/sancus_support/timer.h
+++ b/include/sancus_support/timer.h
@@ -83,45 +83,4 @@ void timerA_isr_entry(void)                                         \
             :::);                                                   \
 }
 
-#define TIMER_ISR_ENTRY2(fct)                                       \
-__attribute__((naked)) __attribute__((interrupt(TIMER_IRQ_VECTOR2)))\
-void timerA_isr_entry2(void)                                        \
-{                                                                   \
-    __asm__ __volatile__(                                           \
-            "cmp #0x0, r1\n\t"                                      \
-            "jne 1f\n\t"                                            \
-            "mov &__isr_sp, r1\n\t"                                 \
-            "push r15\n\t"                                          \
-            "push r2\n\t"                                           \
-            "1: push r15\n\t"                                       \
-            "push r14\n\t"                                          \
-            "push r13\n\t"                                          \
-            "push r12\n\t"                                          \
-            "push r11\n\t"                                          \
-            "push r10\n\t"                                          \
-            "push r9\n\t"                                           \
-            "push r8\n\t"                                           \
-            "push r7\n\t"                                           \
-            "push r6\n\t"                                           \
-            "push r5\n\t"                                           \
-            "push r4\n\t"                                           \
-            "push r3\n\t"                                           \
-            "call #" #fct "\n\t"                                    \
-            "pop r3\n\t"                                            \
-            "pop r4\n\t"                                            \
-            "pop r5\n\t"                                            \
-            "pop r6\n\t"                                            \
-            "pop r7\n\t"                                            \
-            "pop r8\n\t"                                            \
-            "pop r9\n\t"                                            \
-            "pop r10\n\t"                                           \
-            "pop r11\n\t"                                           \
-            "pop r12\n\t"                                           \
-            "pop r13\n\t"                                           \
-            "pop r14\n\t"                                           \
-            "pop r15\n\t"                                           \
-            "reti\n\t"                                              \
-            :::);                                                   \
-}
-
 #endif

--- a/src/sancus-step/sancus_step.c
+++ b/src/sancus-step/sancus_step.c
@@ -23,20 +23,6 @@ int __ss_sm_exit_latency = 0;
 int __ss_isr_interrupted_sm = 0;
 
 /*
- * Determines isr_reti_latency (reti into interrupted module)
- * and sm_exit_latency (from interrupt to isr)
- * and starts timer, so that nemesis can be executed
- */
-void __ss_start(void)
-{
-    if (__ss_dbg_init_done == 0) {
-        __ss_init();
-    }
-    __asm__("dint\n\t"); // disable interrupts
-    timer_irqc(INIT_LATENCY);
-}
-
-/*
  * Determines isr_reti_latency (reti into interrupted moduled)
  * and sm_exit_latency (from interrupt to isr)
  */
@@ -70,6 +56,20 @@ void __ss_init(void)
 
     __ss_dbg_measuring_reti_latency = 0;
     __ss_dbg_init_done = 1;
+}
+
+/*
+ * Determines isr_reti_latency (reti into interrupted module)
+ * and sm_exit_latency (from interrupt to isr)
+ * and starts timer, so that nemesis can be executed
+ */
+void __ss_start(void)
+{
+    if (__ss_dbg_init_done == 0) {
+        __ss_init();
+    }
+    __asm__("dint\n\t"); // disable interrupts
+    timer_irqc(INIT_LATENCY);
 }
 
 void __ss_end(void)

--- a/src/sancus-step/sancus_step.c
+++ b/src/sancus-step/sancus_step.c
@@ -17,6 +17,7 @@ int __ss_get_latency(void)
 
 int __ss_dbg_entry_delay = 0;
 int __ss_dbg_measuring_reti_latency = 0;
+int __ss_dbg_init_done = 0;
 int __ss_isr_reti_latency = 0;
 int __ss_sm_exit_latency = 0;
 int __ss_isr_interrupted_sm = 0;
@@ -28,7 +29,9 @@ int __ss_isr_interrupted_sm = 0;
  */
 void __ss_start(void)
 {
-    __ss_init();
+    if (__ss_dbg_init_done == 0) {
+        __ss_init();
+    }
     __asm__("dint\n\t"); // disable interrupts
     timer_irqc(INIT_LATENCY);
 }
@@ -66,6 +69,7 @@ void __ss_init(void)
     printf("entry delay: %d\n", __ss_dbg_entry_delay);
 
     __ss_dbg_measuring_reti_latency = 0;
+    __ss_dbg_init_done = 1;
 }
 
 void __ss_end(void)


### PR DESCRIPTION
This pull request adds support for consecutive sancus-step runs (`__ss_start` can be called more than once for the same module).

Additional changes:
- Remove duplicated, unused macros from `sancus_step.h` and `timer.h`
- Add comments to assembly blocks to improve readability