### PR TITLE
loader fix for global symbols lookup

### DIFF
--- a/src/loader/global_symtab.c
+++ b/src/loader/global_symtab.c
@@ -21,7 +21,12 @@ static SymbolList* dynamic_symbols_head = NULL;
 
 static int symbol_matches(const Symbol* sym, const char* name)
 {
-    return strcmp(sym->name, name) == 0;
+    int len = strlen(sym->name);
+
+    //fix: ignore weird additional space characters of sym->name
+    for(; len > 0 && sym->name[len - 1] < 33; len--);
+
+    return strncmp(sym->name, name, len) == 0;
 }
 
 size_t symtab_get_num_symbols()


### PR DESCRIPTION
There is a weird bug that occurs when an ELF binary is loaded dynamically. Basically, when we load an ELF, some global symbols  are added in the global symbol table, and everything seems correct here. However, if we want to retrieve the symbol value afterwards, the lookup fails because the symbol name in the table contains weird spacing characters at the end, making `symbol_matches` return `false`.

It is difficult to reproduce this bug because we need to dynamically load an ELF, but I took a screenshot that shows the anomaly:
![Capture](https://user-images.githubusercontent.com/36645341/135070917-9ea7c8a0-af5e-487f-b589-2006d846a69a.PNG)

In this debug logs, I printed the name of the symbol and its length with the format `<name>:<length>`. 

The second line (`Adding symbol...`) is printed when the ELF is loaded dynamically: here the name of the symbol is correct. The following lines are printed when we want to retrieve the value of this symbol: the name printed out is the one stored in the symbol table. You can see that now this symbol for some strange reason has an additional character at the end (a newline).

I inspected the code quite carefully but I couldn't find the reason for this bug. However, I came up with a (temporary) fix to circumvent the bug, by ignoring spacing characters at the end of the symbol name in the comparison performed in `symbol_matches` 
